### PR TITLE
Better code around the message display on signup.

### DIFF
--- a/Deliverance/pages/DeliveranceSignupPage.php
+++ b/Deliverance/pages/DeliveranceSignupPage.php
@@ -75,9 +75,11 @@ abstract class DeliveranceSignupPage extends SiteEditPage
 	protected function handleSubscribeResponse(DeliveranceList $list, $response)
 	{
 		$message = $list->handleSubscribeResponse($response);
+		$message_display = $this->getMessageDisplay();
 
-		if ($message instanceof SwatMessage) {
-			$this->ui->getWidget('message_display')->add($message);
+		if ($message_display instanceof SwatMessageDisplay &&
+			$message instanceof SwatMessage) {
+			$message_display->add($message);
 		}
 	}
 
@@ -153,14 +155,25 @@ abstract class DeliveranceSignupPage extends SiteEditPage
 
 	protected function canRelocate(SwatForm $form)
 	{
-		$relocate = true;
+		$can_relocate = true;
 
-		if ($this->ui->hasWidget('message_display')) {
-			$message_display = $this->ui->getWidget('message_display');
-			$relocate = ($message_display->getMessageCount() == 0);
+		$message_display = $this->getMessageDisplay();
+		if ($message_display instanceof SwatMessageDisplay &&
+			$message_display->getMessageCount() > 0) {
+			$can_relocate = false;
 		}
 
-		return $relocate;
+		return $can_relocate;
+	}
+
+	// }}}
+	// {{{ protected function getMessageDisplay()
+
+	protected function getMessageDisplay()
+	{
+		return $this->ui->getRoot()->getFirstDescendant(
+			'SwatMessageDisplay'
+		);
 	}
 
 	// }}}
@@ -184,7 +197,7 @@ abstract class DeliveranceSignupPage extends SiteEditPage
 				array(
 					'site'      => $this->app->config->notifier->site,
 					'list'      => $list->getShortname(),
-					'interests' => 
+					'interests' =>
 						(isset($info['interests']))
 							? $info['interests']
 							: array(),

--- a/Deliverance/pages/signup.xml
+++ b/Deliverance/pages/signup.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE swatml SYSTEM "http://swat.silverorange.com/swatml1.dtd">
 <swatml>
+	<widget class="SwatMessageDisplay" id="message_display" />
 	<widget class="SwatForm" id="signup_form">
 		<widget class="SwatFrame" id="frame">
 			<widget class="SwatFormField" id="email_field">


### PR DESCRIPTION
- adds the missing default message display that the page class expects.
- makes the code smarter about looking up message display by class, not id so subclasses don't break
- fix relocate check.

This prevents SwatWidgetNotFoundExceptions on live sites, such as https://stage2.silverorange.com/exceptions/essentials/2014-12-10/exception-8982a6a39be2946dcec44c3bf7889032.html

These messages happen when entered a banned address, such as `test@test.com`
