### PR TITLE
Set the subscriber info after we check to see if they are already a member of the list.

### DIFF
--- a/Deliverance/pages/DeliveranceSignupPage.php
+++ b/Deliverance/pages/DeliveranceSignupPage.php
@@ -52,14 +52,18 @@ abstract class DeliveranceSignupPage extends SiteEditPage
 	{
 		$default_info = $list->getDefaultSubscriberInfo();
 
-		$email     = $this->getEmail();
+		$email = $this->getEmail();
+		$this->checkMember($list, $email);
+
 		$info      = $this->getSubscriberInfo($list);
 		$array_map = $this->getArrayMap();
 
-		$this->checkMember($list, $email);
-
-		$response = $list->subscribe($email, $info, $this->send_welcome,
-			$array_map);
+		$response = $list->subscribe(
+			$email,
+			$info,
+			$this->send_welcome,
+			$array_map
+		);
 
 		$this->handleSubscribeResponse($list, $response);
 

--- a/Deliverance/pages/DeliveranceSignupPage.php
+++ b/Deliverance/pages/DeliveranceSignupPage.php
@@ -52,6 +52,10 @@ abstract class DeliveranceSignupPage extends SiteEditPage
 	{
 		$default_info = $list->getDefaultSubscriberInfo();
 
+		// Check to see if the email address is already a member before doing
+		// anything else. This allows the welcome flag to be set correctly,
+		// and for subscriber info to be based on whether it's a new member or
+		// not.
 		$email = $this->getEmail();
 		$this->checkMember($list, $email);
 


### PR DESCRIPTION
This allows the method that sets subscriber info to change the info depending on whether or not they are a member.

This code is messy and relies on the `$welcome_message` flag in weird ways, and should be updated, but that's a bigger job than our immediate needs, so ignoring that for now.