### PR TITLE
Explicitly cast merge_vars and interests to object type

### DIFF
--- a/Deliverance/DeliveranceMailChimpList.php
+++ b/Deliverance/DeliveranceMailChimpList.php
@@ -189,8 +189,8 @@ class DeliveranceMailChimpList extends DeliveranceList
 						'email_address' => $address,
 						'email_type' => $this->email_type,
 						'status' => 'subscribed',
-						'merge_fields' => $merges,
-						'interests' => $interests
+						'merge_fields' => (object) $merges,
+						'interests' => (object) $interests
 					]
 				);
 			} catch (DeliveranceMailChimpTimeoutException $e) {
@@ -249,8 +249,8 @@ class DeliveranceMailChimpList extends DeliveranceList
 						'email_address' => $info['email'],
 						'email_type' => $this->email_type,
 						'status' => 'subscribed',
-						'merge_fields' => $merges,
-						'interests' => $interests
+						'merge_fields' => (object) $merges,
+						'interests' => (object) $interests
 					]
 				);
 
@@ -312,8 +312,8 @@ class DeliveranceMailChimpList extends DeliveranceList
 					),
 					[
 						'email_address' => $address,
-						'merge_fields' => $merges,
-						'interests' => $interests
+						'merge_fields' => (object) $merges,
+						'interests' => (object) $interests
 					]
 				);
 			} catch (DeliveranceMailChimpTimeoutException $e) {
@@ -368,8 +368,8 @@ class DeliveranceMailChimpList extends DeliveranceList
 					),
 					[
 						'email_address' => $info['email'],
-						'merge_fields' => $merges,
-						'interests' => $interests
+						'merge_fields' => (object) $merges,
+						'interests' => (object) $interests
 					]
 				);
 


### PR DESCRIPTION
This is necessary so that empty arrays convert properly and pass the MailChimp schema validation.

I found this bug on EMRAP, where the `MailingListInterest` table is empty. There is an open issue here describing the fix: https://github.com/drewm/mailchimp-api/issues/196 

The schema definition can be found here: https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#create-post_lists_list_id_members Both interests and merge_vars are defined as an object. 