### PR TITLE
Adding deactivated interest support

### DIFF
--- a/Deliverance/DeliveranceMailChimpList.php
+++ b/Deliverance/DeliveranceMailChimpList.php
@@ -612,6 +612,13 @@ class DeliveranceMailChimpList extends DeliveranceList
 		$selected_interests = array_key_exists('interests', $info) ?
 			$info['interests'] : [];
 
+		$deactivated_interests = array_key_exists('deactivated_interests', $info) ?
+			$info['deactivated_interests'] : [];
+
+		foreach ($deactivated_interests as $deactivated_interest) {
+			$interests->{$deactivated_interest} = false;
+		}
+
 		foreach ($selected_interests as $interest) {
 			$interests->{$interest} = true;
 		}


### PR DESCRIPTION
https://airtable.com/tblHi2RES2ktb1XG9/viw4pG7kWWQs7XWjx/recPE99c50lmdpkOs?blocks=hide

This should allow interests that are no longer relevant to a user to be removed. Testing instructions can be found in https://github.com/HippoEducation/hippo/pull/2027