### PR TITLE
Remove unused PEAR dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,6 @@
 	"require": {
 		"php": ">=5.2.1",
 		"ext-mbstring": "*",
-		"pear/mail": "^1.2.0",
-		"pear/mail_mime": "^1.10.0",
-		"pear/net_smtp": "^1.6.3",
 		"silverorange/site": "^9.0.0 || ^10.1.1",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},


### PR DESCRIPTION
Searching the codebase for PEAR, Mail::, Mime, and Net_SMTP yielded no
results. I also looked into the commit history - these packages have
been included as part of the earliest commit, but even in that version
of the codebase, I couldn't find any references to PEAR, Mail::, Mime,
or Net_SMTP. It seems to me that these packages should have never been
considered as dependencies for Deliverance.