### PR TITLE
Bump site version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	"require": {
 		"php": ">=5.2.1",
 		"ext-mbstring": "*",
-		"silverorange/site": "^9.0.0 || ^10.1.1",
+		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
site version 11 just deprecates getSentryClient. deliverance doesn't use it anywhere, so version 11 is also compatible with deliverance.
